### PR TITLE
Replace pug double quote with single quote

### DIFF
--- a/snippets/pug.json
+++ b/snippets/pug.json
@@ -2,28 +2,28 @@
     "v-text": {
         "prefix": "vText",
         "body": [
-            "v-text=\"${1:msg}\""
+            "v-text='${1:msg}'"
         ],
         "description": "Expects: string"
     },
     "v-html": {
         "prefix": "vHtml",
         "body": [
-            "v-html=\"${1:html}\""
+            "v-html='${1:html}'"
         ],
         "description": "Expects: string"
     },
     "v-show": {
         "prefix": "vShow",
         "body": [
-            "v-show=\"${1:condition}\""
+            "v-show='${1:condition}'"
         ],
         "description": "Expects: any"
     },
     "v-if": {
         "prefix": "vIf",
         "body": [
-            "v-if=\"${1:condition}\""
+            "v-if='${1:condition}'"
         ],
         "description": "Expects: any"
     },
@@ -37,42 +37,42 @@
     "v-else-if": {
         "prefix": "vElseIf",
         "body": [
-            "v-else-if=\"${1:condition}\""
+            "v-else-if='${1:condition}'"
         ],
         "description": "Expects: any. previous sibling element must have v-if or v-else-if."
     },
     "v-for-without-key": {
         "prefix": "vForWithoutKey",
         "body": [
-            "v-for=\"${1:item} in ${2:items}\""
+            "v-for='${1:item} in ${2:items}'"
         ],
         "description": "Expects: Array | Object | number | string"
     },
     "v-for": {
         "prefix": "vFor",
         "body": [
-            "v-for=\"${1:item} in ${2:items}\" :key=\"${3:item.id}\""
+            "v-for='${1:item} in ${2:items}' :key='${3:item.id}'"
         ],
         "description": "Expects: Array | Object | number | string"
     },
     "v-on": {
         "prefix": "vOn",
         "body": [
-            "v-on:${1:event}=\"${2:handle}\""
+            "v-on:${1:event}='${2:handle}'"
         ],
         "description": "Expects: Function | Inline Statement"
     },
     "v-bind": {
         "prefix": "vBind",
         "body": [
-            "v-bind$1=\"${2}\""
+            "v-bind$1='${2}'"
         ],
         "description": "Expects: any (with argument) | Object (without argument)"
     },
     "v-model": {
         "prefix": "vModel",
         "body": [
-            "v-model=\"${1:something}\""
+            "v-model='${1:something}'"
         ],
         "description": "Expects: varies based on value of form inputs element or output of components"
     },
@@ -100,21 +100,21 @@
     "key": {
         "prefix": "key",
         "body": [
-            ":key=\"${1:key}\""
+            ":key='${1:key}'"
         ],
         "description": "Expects: string. Children of the same common parent must have unique keys. Duplicate keys will cause render errors."
     },
     "ref": {
         "prefix": "ref",
         "body": [
-            "ref=\"${1:reference}\"$0"
+            "ref='${1:reference}'$0"
         ],
         "description": "Expects: string. ref is used to register a reference to an element or a child component. The reference will be registered under the parent component’s $refs object. If used on a plain DOM element, the reference will be that element; if used on a child component, the reference will be component instance."
     },
     "slotA": {
         "prefix": "slotA",
         "body": [
-            "slot=\"$1\"$0"
+            "slot='$1'$0"
         ],
         "description": "slot=''. Expects: string. Used on content inserted into child components to indicate which named slot the content belongs to."
     },
@@ -128,21 +128,21 @@
     "slotScope": {
         "prefix": "slotScope",
         "body": [
-            "slot-scope=\"$1\"$0"
+            "slot-scope='$1'$0"
         ],
         "description": "Used to denote an element or component as a scoped slot. The attribute’s value should be a valid JavaScript expression that can appear in the argument position of a function signature. This means in supported environments you can also use ES2015 destructuring in the expression. Serves as a replacement for scope in 2.5.0+."
     },
     "scope": {
         "prefix": "scope",
         "body": [
-            "scope=\"${1:this api replaced by slot-scope in 2.5.0+}\"$0"
+            "scope='${1:this api replaced by slot-scope in 2.5.0+}'$0"
         ],
         "description": "Used to denote a <template> element as a scoped slot, which is replaced by `slot-scope` in 2.5.0+."
     },
     "component": {
         "prefix": "component",
         "body": [
-            "component(:is=\"${1:componentId}\") $0"
+            "component(:is='${1:componentId}') $0"
         ],
         "description": "component element"
     },
@@ -170,147 +170,147 @@
     "enter-class": {
         "prefix": "enterClass",
         "body": [
-            "enter-class=\"$1\"$0"
+            "enter-class='$1'$0"
         ],
         "description": "enter-class=''. Expects: string."
     },
     "leave-class": {
         "prefix": "leaveClass",
         "body": [
-            "leave-class=\"$1\"$0"
+            "leave-class='$1'$0"
         ],
         "description": "leave-class=''. Expects: string."
     },
     "appear-class": {
         "prefix": "appearClass",
         "body": [
-            "appear-class=\"$1\"$0"
+            "appear-class='$1'$0"
         ],
         "description": "appear-class=''. Expects: string."
     },
     "enter-to-class": {
         "prefix": "enterToClass",
         "body": [
-            "enter-to-class=\"$1\"$0"
+            "enter-to-class='$1'$0"
         ],
         "description": "enter-to-class=''. Expects: string."
     },
     "leave-to-class": {
         "prefix": "leaveToClass",
         "body": [
-            "leave-to-class=\"$1\"$0"
+            "leave-to-class='$1'$0"
         ],
         "description": "leave-to-class=''. Expects: string."
     },
     "appear-to-class": {
         "prefix": "appearToClass",
         "body": [
-            "appear-to-class=\"$1\"$0"
+            "appear-to-class='$1'$0"
         ],
         "description": "appear-to-class=''. Expects: string."
     },
     "enter-active-class": {
         "prefix": "enterActiveClass",
         "body": [
-            "enter-active-class=\"$1\"$0"
+            "enter-active-class='$1'$0"
         ],
         "description": "enter-active-class=''. Expects: string."
     },
     "leave-active-class": {
         "prefix": "leaveActiveClass",
         "body": [
-            "leave-active-class=\"$1\"$0"
+            "leave-active-class='$1'$0"
         ],
         "description": "leave-active-class=''. Expects: string."
     },
     "appear-active-class": {
         "prefix": "appearActiveClass",
         "body": [
-            "appear-active-class=\"$1\"$0"
+            "appear-active-class='$1'$0"
         ],
         "description": "appear-active-class=''. Expects: string."
     },
     "before-enter": {
         "prefix": "beforeEnterEvent",
         "body": [
-            "@before-enter=\"$1\"$0"
+            "@before-enter='$1'$0"
         ],
         "description": "@before-enter=''"
     },
     "before-leave": {
         "prefix": "beforeLeaveEvent",
         "body": [
-            "@before-leave=\"$1\"$0"
+            "@before-leave='$1'$0"
         ],
         "description": "@before-leave=''"
     },
     "before-appear": {
         "prefix": "beforeAppearEvent",
         "body": [
-            "@before-appear=\"$1\"$0"
+            "@before-appear='$1'$0"
         ],
         "description": "@before-appear=''"
     },
     "enter": {
         "prefix": "enterEvent",
         "body": [
-            "@enter=\"$1\"$0"
+            "@enter='$1'$0"
         ],
         "description": "@enter=''"
     },
     "leave": {
         "prefix": "leaveEvent",
         "body": [
-            "@leave=\"$1\"$0"
+            "@leave='$1'$0"
         ],
         "description": "@leave=''"
     },
     "appear": {
         "prefix": "appearEvent",
         "body": [
-            "@appear=\"$1\"$0"
+            "@appear='$1'$0"
         ],
         "description": "@appear=''"
     },
     "after-enter": {
         "prefix": "afterEnterEvent",
         "body": [
-            "@after-enter=\"$1\"$0"
+            "@after-enter='$1'$0"
         ],
         "description": "@after-enter=''"
     },
     "after-leave": {
         "prefix": "afterLeaveEvent",
         "body": [
-            "@after-leave=\"$1\"$0"
+            "@after-leave='$1'$0"
         ],
         "description": "@after-leave=''"
     },
     "after-appear": {
         "prefix": "afterAppearEvent",
         "body": [
-            "@after-appear=\"$1\"$0"
+            "@after-appear='$1'$0"
         ],
         "description": "@after-appear=''"
     },
     "enter-cancelled": {
         "prefix": "enterCancelledEvent",
         "body": [
-            "@enter-cancelled=\"$1\"$0"
+            "@enter-cancelled='$1'$0"
         ],
         "description": "@enter-cancelled=''"
     },
     "leave-cancelled": {
         "prefix": "leaveCancelledEvent",
         "body": [
-            "@leave-cancelled=\"$1\"$0"
+            "@leave-cancelled='$1'$0"
         ],
         "description": "@leave-cancelled='' (v-show only)"
     },
     "appear-cancelled": {
         "prefix": "appearCancelledEvent",
         "body": [
-            "@appear-cancelled=\"$1\"$0"
+            "@appear-cancelled='$1'$0"
         ],
         "description": "@appear-cancelled=''"
     },
@@ -324,21 +324,21 @@
     "routerLinkTo": {
         "prefix": "routerLinkTo",
         "body": [
-            "router-link (to=\"$1\") $0"
+            "router-link (to='$1') $0"
         ],
         "description": "router-link (to='') . router-link element"
     },
     "to": {
         "prefix": "to",
         "body": [
-            "to=\"$1\"$0"
+            "to='$1'$0"
         ],
         "description": "to=''"
     },
     "tag": {
         "prefix": "tag",
         "body": [
-            "tag=\"$1\"$0"
+            "tag='$1'$0"
         ],
         "description": "tag=''"
     },


### PR DESCRIPTION
resolves #28 

Although it's not explicitly mentioned in pug's documentation, but I think using single quote is more recommended according to its official [examples](https://pugjs.org/language/attributes.html).